### PR TITLE
docs: Add documentation for article references

### DIFF
--- a/docs/article_references.md
+++ b/docs/article_references.md
@@ -1,0 +1,92 @@
+# Handling Article References
+
+
+## Prerequisites
+Before tackling article references, you need to understand the [rich_text](./supported_types.md#rich_text) type.
+
+## What kind of references are supported?
+We support references to artifacts and articles. An inline attachment must be mapped to an artifact. A link to another article must be mapped to an article.
+
+## How to handle references?
+
+### Inline attachments
+If an inline attachment is hosted in the source system, it must be created as an artifact in DevRev. The same link cannot be used as the attachment will be deleted in the source system when our customers deactivate the account. However, creating an artifact is not enough. The artifact must linked in the appropriate place in the article content. 
+
+#### HTML
+```
+<img src="don:core:dvrv-us-1:devo/0:artifact/1" alt="Alt Text"/>
+```
+
+#### Markdown
+```
+![Alt Text](don:core:dvrv-us-1:devo/0:artifact/1)
+```
+
+#### Example
+Let's say the content of your external system looks like this:
+```
+<p>This is an article with one image.</p>
+<p><img src="https://devrev.zendesk.com/hc/article_attachments/29908544740244" alt="download.jpeg"></p>
+```
+
+The content in DevRev should look like this:
+```
+<p>This is an article with one image.</p>
+<p><img src="don:core:dvrv-us-1:devo/0:artifact/1" alt="download.jpeg"></p>
+```
+
+`don:core:dvrv-us-1:devo/0:artifact/1` is the ID of the artifact created in DevRev.
+To achieve this, you need to transform the content of the article to this:
+```json
+{
+    "type": "rich_text",
+    "content": [
+        "<p>This is an article with one image.</p><p><img src=\"",
+        {
+            "ref_type": "artifact",
+            "id": "29908544740244",
+            "fallback_record_name": "<fallback link>"
+        },
+        "\" alt=\"download.jpeg\"></p>"
+    ]
+}
+```
+The platform simply replaces the reference block with the ID of the artifact. The resolved value in not wrapped in double quotes. 
+
+### Links to other articles
+If an article links to another article, you need to create a reference to the article in the content of the article. This is important because at the extractor stage, it is impossible to predict the ID of the article that will be created in DevRev. This feature is only available for HTML format. However, since Markdown can contain HTML, you can use the same approach for Markdown as well.
+
+#### HTML
+```
+<a data-article-id="don:core:dvrv-us-1:devo/0:article/10" href="/ART-10" target="_self">Contact our Support Team</a>
+```
+
+#### Example
+Let's say the content of your external system looks like this:
+```
+<p>You can create an account and log-in <a href="https://devrev.zendesk.com/hc/en-us/articles/360059607772" target="_self">only</a> with the company email.
+```
+
+The content in DevRev should look like this:
+```
+<p>You can create an account and log-in <a data-article-id="don:core:dvrv-us-1:devo/0:article/10" href="/ART-10" target="_self">only</a> with the company email.
+```
+
+`don:core:dvrv-us-1:devo/0:article/10` is the ID of the article created in DevRev.
+To achieve this, you need to transform the content of the article to this:
+```json
+{
+    "type": "rich_text",
+    "content": [
+        "You can create an account and log-in <a data-article-id=\"",
+        {
+            "ref_type": "article",
+            "id": "360059607772",
+            "fallback_record_name": "<fallback article ID>"
+        },
+        "\" target=\"_self\"> only</a> with the company email."
+    ]
+}
+```
+
+The platform replaces the reference block with the ID of the article as well as adds the href attribute with the appropriate value.

--- a/docs/article_references.md
+++ b/docs/article_references.md
@@ -1,6 +1,5 @@
 # Handling Article References
 
-
 ## Prerequisites
 Before tackling article references, you need to understand the [rich_text](./supported_types.md#rich_text) type.
 
@@ -35,7 +34,7 @@ The content in DevRev should look like this:
 <p><img src="don:core:dvrv-us-1:devo/0:artifact/1" alt="download.jpeg"></p>
 ```
 
-`don:core:dvrv-us-1:devo/0:artifact/1` is the ID of the artifact created in DevRev.
+`don:core:dvrv-us-1:devo/0:artifact/1` is the ID of the artifact created in DevRev corresponding to the attachment with ID `29908544740244` in the external source system.
 To achieve this, you need to transform the content of the article to this:
 ```json
 {
@@ -54,7 +53,7 @@ To achieve this, you need to transform the content of the article to this:
 The platform simply replaces the reference block with the ID of the artifact. The resolved value in not wrapped in double quotes. 
 
 ### Links to other articles
-If an article links to another article, you need to create a reference to the article in the content of the article. This is important because at the extractor stage, it is impossible to predict the ID of the article that will be created in DevRev. This feature is only available for HTML format. However, since Markdown can contain HTML, you can use the same approach for Markdown as well.
+If there is a link to another article in the content of the article, you need to create a reference to the article. The link must be to an article that was either created in previous syncs or will be created in the current sync. At the extractor stage, it is impossible to predict the ID of the article that will be created in DevRev. So, this must be handled by the platform. This feature is only available for HTML format. However, since Markdown can contain HTML, you can use the same approach for Markdown as well.
 
 #### HTML
 ```
@@ -72,7 +71,7 @@ The content in DevRev should look like this:
 <p>You can create an account and log-in <a data-article-id="don:core:dvrv-us-1:devo/0:article/10" href="/ART-10" target="_self">only</a> with the company email.
 ```
 
-`don:core:dvrv-us-1:devo/0:article/10` is the ID of the article created in DevRev.
+`don:core:dvrv-us-1:devo/0:article/10` is the ID of the article created in DevRev corresponding to the article with ID `360059607772` in the external source system.
 To achieve this, you need to transform the content of the article to this:
 ```json
 {
@@ -88,5 +87,4 @@ To achieve this, you need to transform the content of the article to this:
     ]
 }
 ```
-
 The platform replaces the reference block with the ID of the article as well as adds the href attribute with the appropriate value.

--- a/docs/article_references.md
+++ b/docs/article_references.md
@@ -36,21 +36,18 @@ The content in DevRev should look like this:
 
 `don:core:dvrv-us-1:devo/0:artifact/1` is the ID of the artifact created in DevRev corresponding to the attachment with ID `29908544740244` in the external source system.
 To achieve this, you need to transform the content of the article to this:
-```json
-{
-    "type": "rich_text",
-    "content": [
-        "<p>This is an article with one image.</p><p><img src=\"",
-        {
-            "ref_type": "artifact",
-            "id": "29908544740244",
-            "fallback_record_name": "<fallback link>"
-        },
-        "\" alt=\"download.jpeg\"></p>"
-    ]
-}
 ```
-The platform simply replaces the reference block with the ID of the artifact. The resolved value in not wrapped in double quotes. 
+[ 
+    "<p>This is an article with one image.</p><p><img src=\"",
+    {
+        "ref_type": "artifact",
+        "id": "29908544740244",
+        "fallback_record_name": "<fallback link>"
+    },
+    "\" alt=\"download.jpeg\"></p>" 
+]
+```
+The ref_type should be set to artifact and the ID should be the ID of the attachment in the external source system. The platform simply replaces the reference block with the ID of the corresponding artifact. The resolved value in not wrapped in double quotes. 
 
 ### Links to other articles
 If there is a link to another article in the content of the article, you need to create a reference to the article. The link must be to an article that was either created in previous syncs or will be created in the current sync. At the extractor stage, it is impossible to predict the ID of the article that will be created in DevRev. So, this must be handled by the platform. This feature is only available for HTML format. However, since Markdown can contain HTML, you can use the same approach for Markdown as well.
@@ -73,18 +70,15 @@ The content in DevRev should look like this:
 
 `don:core:dvrv-us-1:devo/0:article/10` is the ID of the article created in DevRev corresponding to the article with ID `360059607772` in the external source system.
 To achieve this, you need to transform the content of the article to this:
-```json
-{
-    "type": "rich_text",
-    "content": [
-        "You can create an account and log-in <a data-article-id=\"",
-        {
-            "ref_type": "article",
-            "id": "360059607772",
-            "fallback_record_name": "<fallback article ID>"
-        },
-        "\" target=\"_self\"> only</a> with the company email."
-    ]
-}
 ```
-The platform replaces the reference block with the ID of the article as well as adds the href attribute with the appropriate value.
+[
+    "You can create an account and log-in <a data-article-id=\"",
+    {
+        "ref_type": "article",
+        "id": "360059607772",
+        "fallback_record_name": "<fallback article ID>"
+    },
+    "\" target=\"_self\"> only</a> with the company email."
+]
+```
+The ref_type should be set to article and the ID should be the ID of the article in the external source system. The platform replaces the reference block with the ID of the article as well as adds the href attribute with the appropriate value.

--- a/docs/article_references.md
+++ b/docs/article_references.md
@@ -81,4 +81,4 @@ To achieve this, you need to transform the content of the article to this:
     "\" target=\"_self\"> only</a> with the company email."
 ]
 ```
-The ref_type should be set to article and the ID should be the ID of the article in the external source system. The platform replaces the reference block with the ID of the article as well as adds the href attribute with the appropriate value.
+The ref_type should be set to the item type in the external system that is being mapped to articles. For example, if you're importing documents from the external system as articles, the `ref_type` should be set to documents. The ID should be the ID of the item in the external source system. The platform replaces the reference block with the ID of the corresponding article in DevRev as well as adds the href attribute with the appropriate value.

--- a/docs/supported_types.md
+++ b/docs/supported_types.md
@@ -46,7 +46,7 @@ DevRev supports the following types:
       ]
     }
     ```
-  - Articles don't use markdown, but a custom format, refer to DevRev documentation for more details.
+  - Articles support Markdown as well as HTML. For more details, refer to [article references](article_references.md).
 
 - `reference`: IDs referring to another record. References have to declare what they can refer to,
   which can be one or more record types (`#record:`) or categories (`#category:`).


### PR DESCRIPTION
I've added some basic documentation for handling article references.